### PR TITLE
new test for file copying, currently fails

### DIFF
--- a/src/test/java/net/beargummy/filesystem/CopyLargeFileTest.java
+++ b/src/test/java/net/beargummy/filesystem/CopyLargeFileTest.java
@@ -1,0 +1,53 @@
+package net.beargummy.filesystem;
+
+import org.junit.Test;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Random;
+
+import static org.junit.Assert.assertTrue;
+
+public class CopyLargeFileTest {
+  @Test
+  public void test() throws IOException {
+    java.io.File fsFile = Files.createTempFile("filesystem", ".dat").toFile();
+    java.io.File srcFile = Files.createTempFile("source", ".dat").toFile();
+
+    Writer fw = new BufferedWriter(new FileWriter(srcFile), 8192);
+
+    long size = 1024 * 1024;
+    Random rnd = new Random();
+    while (srcFile.length() < size) {
+      final int[] ints = rnd.ints(1024).toArray();
+      for (int i=0; i<ints.length; i++)
+        fw.write(i);
+    }
+
+    fw.close();
+
+    int blockSize = 8192;
+    int blockCount = Math.round(srcFile.length() / blockSize);
+
+    FileSystem fileSystem = FileSystemManager.getInstance()
+        .create(fsFile, blockSize, blockCount);
+
+    File newFile = fileSystem.createFile("/file.dat");
+
+    byte[] buffer = new byte[1111];
+    InputStream is = new BufferedInputStream(new FileInputStream(srcFile));
+    try {
+      while (true) {
+        int numRead = is.read(buffer);
+        if (numRead <= 0) break;
+
+        newFile.append(buffer, 0, numRead);
+      }
+    } finally {
+      is.close();
+    }
+
+    assertTrue(fsFile.delete());
+    assertTrue(srcFile.delete());
+  }
+}


### PR DESCRIPTION
This test fails with:

java.lang.IllegalArgumentException: Data is greater than block
	at net.beargummy.filesystem.SingleFileBlockStorage.assertOffsetValid(SingleFileBlockStorage.java:54)
	at net.beargummy.filesystem.SingleFileBlockStorage.writeBlock(SingleFileBlockStorage.java:41)
	at net.beargummy.filesystem.PersistenceManager.writeINodeData(PersistenceManager.java:143)
	at net.beargummy.filesystem.DefaultFileSystem.writeINodeData(DefaultFileSystem.java:266)
	at net.beargummy.filesystem.DefaultFile.append(DefaultFile.java:77)
	at net.beargummy.filesystem.CopyLargeFileTest.test(CopyLargeFileTest.java:44)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)

In addition to that, it seems impossible to delete file system file from disk in the same process where it was created. It happens because FileSystemManager.create method creates RandomAccessFile and this RAF is never closed. Also there is no API to close the file system.

