### PR TITLE
Make FileSystem and File closable

### DIFF
--- a/src/main/java/net/beargummy/filesystem/BlockStorage.java
+++ b/src/main/java/net/beargummy/filesystem/BlockStorage.java
@@ -2,7 +2,7 @@ package net.beargummy.filesystem;
 
 import java.io.IOException;
 
-public interface BlockStorage {
+public interface BlockStorage extends AutoCloseable {
 
     /**
      * Reads up to {@code buffer.length} bytes of block buffer into an array of bytes.
@@ -70,4 +70,12 @@ public interface BlockStorage {
      */
     long getBlocksCount();
 
+    /**
+     * Closes {@code BlockStorage} and all closes/frees used resources.
+     *
+     * @throws IOException if an I/O error occurs.
+     * @throws Exception   if other error occurs.
+     */
+    @Override
+    void close() throws Exception;
 }

--- a/src/main/java/net/beargummy/filesystem/File.java
+++ b/src/main/java/net/beargummy/filesystem/File.java
@@ -21,8 +21,9 @@ public interface File extends AutoCloseable {
      * Reads up to {@code buffer.length} bytes of data from this file into an array of bytes.
      *
      * @param buffer the buffer into which the data is read.
-     * @throws NullPointerException if {@code buffer} is {@code null}.
-     * @throws IOException          if an I/O error occurs.
+     * @throws NullPointerException  if {@code buffer} is {@code null}.
+     * @throws IllegalStateException if file or related {@link FileSystem} is closed
+     * @throws IOException           if an I/O error occurs.
      */
     int read(byte[] buffer) throws IOException;
 
@@ -33,8 +34,9 @@ public interface File extends AutoCloseable {
      *
      * @param buffer   the buffer into which the data is read.
      * @param position the start position in the file.
-     * @throws NullPointerException if {@code buffer} is {@code null}.
-     * @throws IOException          if an I/O error occurs.
+     * @throws NullPointerException  if {@code buffer} is {@code null}.
+     * @throws IllegalStateException if file or related {@link FileSystem} is closed
+     * @throws IOException           if an I/O error occurs.
      */
     int read(byte[] buffer, long position) throws IOException;
 
@@ -49,6 +51,7 @@ public interface File extends AutoCloseable {
      * @param position the start position in the file.
      * @throws IllegalArgumentException if {@code offset} is negative or greater than file size.
      * @throws NullPointerException     if {@code buffer} is {@code null}.
+     * @throws IllegalStateException    if file or related {@link FileSystem} is closed
      * @throws IOException              if an I/O error occurs.
      */
     int read(byte[] buffer, int offset, int length, long position) throws IOException;
@@ -57,8 +60,9 @@ public interface File extends AutoCloseable {
      * Writes {@code buffer.length} bytes from the specified byte array to this file.
      *
      * @param buffer the buffer.
-     * @throws NullPointerException if {@code buffer} is {@code null}.
-     * @throws IOException          if an I/O error occurs.
+     * @throws NullPointerException  if {@code buffer} is {@code null}.
+     * @throws IllegalStateException if file or related {@link FileSystem} is closed
+     * @throws IOException           if an I/O error occurs.
      */
     int write(byte[] buffer) throws IOException;
 
@@ -72,6 +76,7 @@ public interface File extends AutoCloseable {
      * @param position the start position in the file.
      * @throws IllegalArgumentException if {@code offset} is negative.
      * @throws NullPointerException     if {@code buffer} is {@code null}.
+     * @throws IllegalStateException    if file or related {@link FileSystem} is closed
      * @throws IOException              if an I/O error occurs.
      */
     int write(byte[] buffer, int offset, int length, long position) throws IOException;
@@ -82,6 +87,7 @@ public interface File extends AutoCloseable {
      * @param buffer the buffer.
      * @throws IllegalArgumentException if {@code offset} is negative.
      * @throws NullPointerException     if {@code buffer} is {@code null}.
+     * @throws IllegalStateException    if file or related {@link FileSystem} is closed
      * @throws IOException              if an I/O error occurs.
      */
     int append(byte[] buffer) throws IOException;
@@ -95,6 +101,7 @@ public interface File extends AutoCloseable {
      * @param length amount of bytes to write from {@code buffer}
      * @throws IllegalArgumentException if {@code offset} is negative.
      * @throws NullPointerException     if {@code buffer} is {@code null}.
+     * @throws IllegalStateException    if file or related {@link FileSystem} is closed
      * @throws IOException              if an I/O error occurs.
      */
     int append(byte[] buffer, int offset, int length) throws IOException;
@@ -104,6 +111,8 @@ public interface File extends AutoCloseable {
      * Note, data can be stale.
      *
      * @return size of the file data space in bytes
+     * @throws IllegalStateException if file or related {@link FileSystem} is closed
+     * @throws IOException           if an I/O error occurs.
      */
     long getFileSize() throws IOException;
 

--- a/src/main/java/net/beargummy/filesystem/File.java
+++ b/src/main/java/net/beargummy/filesystem/File.java
@@ -8,7 +8,7 @@ import java.io.IOException;
  * Supports methods to access it's content.
  * For a file management {@link FileSystem} should be used instead.
  */
-public interface File {
+public interface File extends AutoCloseable {
 
     /**
      * Get file name.
@@ -101,9 +101,19 @@ public interface File {
 
     /**
      * Get file size in bytes.
+     * Note, data can be stale.
      *
      * @return size of the file data space in bytes
      */
-    long getFileSize();
+    long getFileSize() throws IOException;
 
+    /**
+     * Closes {@code File}.
+     * A closed file cannot perform IO operations.
+     *
+     * @throws IOException if an I/O error occurs.
+     * @throws Exception   if other error occurs.
+     */
+    @Override
+    void close() throws Exception;
 }

--- a/src/main/java/net/beargummy/filesystem/FileSystem.java
+++ b/src/main/java/net/beargummy/filesystem/FileSystem.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 /**
  * File system interface.
  */
-public interface FileSystem {
+public interface FileSystem extends AutoCloseable {
 
     /**
      * Create new empty {@link File file} with given name.
@@ -50,4 +50,12 @@ public interface FileSystem {
      */
     void deleteFile(String name) throws IOException;
 
+    /**
+     * Closes {@code FileSystem} and underlying {@link BlockStorage}.
+     *
+     * @throws IOException if an I/O error occurs.
+     * @throws Exception   if other error occurs.
+     */
+    @Override
+    void close() throws Exception;
 }

--- a/src/main/java/net/beargummy/filesystem/FileSystem.java
+++ b/src/main/java/net/beargummy/filesystem/FileSystem.java
@@ -18,6 +18,7 @@ public interface FileSystem extends AutoCloseable {
      * @throws NullPointerException     if file name is {@code null}.
      * @throws IllegalArgumentException if file name is empty string.
      * @throws FileAlreadyExists        if file already exists.
+     * @throws IllegalStateException    if FileSystem is closed
      * @throws IOException              if an I/O error occurs.
      */
     File createFile(String name) throws IOException;
@@ -32,6 +33,7 @@ public interface FileSystem extends AutoCloseable {
      * @throws NullPointerException     if file name is {@code null}.
      * @throws IllegalArgumentException if file name is empty string.
      * @throws FileNotFoundException    if the file does not exist.
+     * @throws IllegalStateException    if FileSystem is closed
      * @throws IOException              if an I/O error occurs.
      */
     File openFile(String name) throws IOException;
@@ -46,6 +48,7 @@ public interface FileSystem extends AutoCloseable {
      * @throws NullPointerException     if file name is {@code null}.
      * @throws IllegalArgumentException if file name is empty string.
      * @throws FileNotFoundException    if the file does not exist.
+     * @throws IllegalStateException    if FileSystem is closed
      * @throws IOException              if an I/O error occurs.
      */
     void deleteFile(String name) throws IOException;

--- a/src/main/java/net/beargummy/filesystem/InMemoryBlockStorage.java
+++ b/src/main/java/net/beargummy/filesystem/InMemoryBlockStorage.java
@@ -1,29 +1,35 @@
 package net.beargummy.filesystem;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Simplest in-memory block storage for debugging simplification.
  */
 class InMemoryBlockStorage implements BlockStorage {
 
-    private final byte[][] storage;
+    private byte[][] storage;
     private final int blocksCount;
     private final int blockSize;
+
+    private final AtomicBoolean closed;
 
     InMemoryBlockStorage(int blockSize, int blocksCount) {
         this.storage = new byte[blocksCount][blockSize];
         this.blocksCount = blocksCount;
         this.blockSize = blockSize;
+        closed = new AtomicBoolean(false);
     }
 
     @Override
     public int readBlock(long blockNumber, byte[] buffer) throws IOException {
+        assertNotClosed();
         return readBlock(blockNumber, buffer, 0, blockSize, 0);
     }
 
     @Override
     public int readBlock(long blockNumber, byte[] buffer, int offset, int length, long position) throws IOException {
+        assertNotClosed();
         if (blockNumber > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("huge block numbers unsupported");
         }
@@ -36,11 +42,13 @@ class InMemoryBlockStorage implements BlockStorage {
 
     @Override
     public void writeBlock(long blockNumber, byte[] buffer) throws IOException {
+        assertNotClosed();
         writeBlock(blockNumber, buffer, 0, blockSize, 0);
     }
 
     @Override
     public void writeBlock(long blockNumber, byte[] buffer, int offset, int length, long position) throws IOException {
+        assertNotClosed();
         if (blockNumber > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("huge block numbers unsupported");
         }
@@ -52,11 +60,27 @@ class InMemoryBlockStorage implements BlockStorage {
 
     @Override
     public int getBlockSize() {
+        assertNotClosed();
         return blockSize;
     }
 
     @Override
     public long getBlocksCount() {
+        assertNotClosed();
         return blocksCount;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        storage = null; // free memory
+    }
+
+    private void assertNotClosed() {
+        if (closed.get()) {
+            throw new IllegalStateException("Block storage closed");
+        }
     }
 }


### PR DESCRIPTION
Make FileSystem and File closable to allow free used resources such as opened file for file-based block storage or byte arrays for in-memory block storage.